### PR TITLE
slice: Split with "encoding/csv" so commas can be escaped

### DIFF
--- a/slice.go
+++ b/slice.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"encoding/csv"
 
 	"github.com/spf13/pflag"
 )
@@ -45,7 +46,12 @@ func (s *SliceValue[T]) Unredacted() pflag.Value {
 }
 
 func (s *SliceValue[T]) Set(val string) error {
-	ss := strings.Split(val, ",")
+	r := strings.NewReader(val)
+	cr := csv.NewReader(r)
+	ss, err := cr.Read()
+	if err != nil {
+		return err
+	}
 	out := make([]T, len(ss))
 	for i, d := range ss {
 		var err error

--- a/slice_test.go
+++ b/slice_test.go
@@ -30,6 +30,12 @@ func setUpDSFlagSetWithRedact(dsp *[]time.Duration) *pflag.FlagSet {
 	return f
 }
 
+func setUpSSFlagSet(ssp *[]string) *pflag.FlagSet {
+	f := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	f.StringSliceVar(ssp, "ss", []string{}, "Command separated list!")
+	return f
+}
+
 func TestEmptyDS(t *testing.T) {
 	var ds []time.Duration
 	f := setUpDSFlagSet(&ds)
@@ -166,5 +172,28 @@ func TestDSCalledTwice(t *testing.T) {
 		if expected[i] != v {
 			t.Fatalf("expected ds[%d] to be %d but got: %d", i, expected[i], v)
 		}
+	}
+}
+
+func TestWithCommas(t *testing.T) {
+	var ss []string
+
+	f := setUpSSFlagSet(&ss)
+	in := []string{`"foo=1,2"`, `"bar=3"`}
+	expected := []string{"foo=1,2", "bar=3"}
+	argfmt := "--ss=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+
+	}
+	for i, v := range ss {
+		if expected[i] != v {
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, expected[i], v)
+
+		}
+
 	}
 }


### PR DESCRIPTION
Currently there is no way to pass a slice value that contains a comma.

For example:

```
cmd --ss \"foo,bar\" --ss baz
```

would be interpreted as `[]string{"foo", "bar", "baz"}`

This change uses the `csv` module which handles quotes to escape the values.

```
cmd --ss \"foo,bar\" --ss baz
```

would be interpreted as `[]string{"foo, bar", "baz"}`

See https://github.com/spf13/pflag/pull/59 for more details.